### PR TITLE
components: sort list by GitHub issue title

### DIFF
--- a/src/components/components/index.js
+++ b/src/components/components/index.js
@@ -6,9 +6,20 @@ import useDidMount from "../useDidMount";
 export default ({ loading, components }) => {
   const [hasMounted] = useDidMount();
 
+  // Copy and sort by the GitHub issue title
+  const sorted = [...components];
+  sorted.sort((a, b) => {
+    if (a.title < b.title) {
+      return -1;
+    } else if (a.title > b.title) {
+      return 1;
+    }
+    return 0;
+  });
+
   return !loading || hasMounted ? (
-    components?.length > 0 ? (
-      components?.map((component) => (
+    sorted?.length > 0 ? (
+      sorted?.map((component) => (
         <Component key={component.id} component={component} />
       ))
     ) : (


### PR DESCRIPTION
It was bothering me that the list of components is in ~random order (i.e. whatever order the GitHub API returned), so I figured I'd fix that. I chose to sort alphabetically by the GitHub issue title; does that seem reasonable?