### PR TITLE
incident.comment: fix spurious newlines outside <p>

### DIFF
--- a/src/components/incidents/incident/index.js
+++ b/src/components/incidents/incident/index.js
@@ -35,8 +35,10 @@ const Title = styled.div`
 `;
 
 const Comment = styled.div`
-  white-space: break-spaces;
   color: #1e1e1e;
+  p {
+    white-space: break-spaces;
+  }
 `;
 
 const Status = styled.div`


### PR DESCRIPTION
Move `white-space: break-spaces` within `<p>` tags, so that the newlines between paragraphs aren’t rendered out, but newlines within paragraphs are preserved.

#### Before
![Screenshot From 2025-05-23 02-25-18](https://github.com/user-attachments/assets/6f29463c-1f99-42df-a06c-5d30f949dd90)

#### After
![Screenshot From 2025-05-23 02-27-13](https://github.com/user-attachments/assets/6d54381b-4233-4621-b24b-a7a2630198e6)
